### PR TITLE
ref(quick-start): simplify networking

### DIFF
--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -36,14 +36,10 @@ This example creates the following resources in the provided AWS account:
   - 1 Elastic IP address (associated with instance)
     - This is useful as it won't change with instance reboots and is a known
       value for constructing Hippo and Bindle URLs
-  - 1 VPC to host the EC2 instance, using a private IP address range
-    - 1 subnet
-    - 1 network interface
-    - 1 custom security group with
-      - Inbound connections allowed for ports 22, 80 and 443
-        - see `var.allowed_inbound_cidr_blocks` for allowed origin IP addresses
-      - All outbound connections allowed
-    - 1 internet gateway and route table for connection to the broader internet
+  - 1 custom security group using the default VPC with:
+    - Inbound connections allowed for ports 22, 80 and 443
+      - see `var.allowed_inbound_cidr_blocks` for allowed origin IP addresses
+    - All outbound connections allowed
   - 1 SSH keypair
     - see `var.allowed_ssh_cidr_blocks` for allowed origin IP addresses
 

--- a/quick-start/terraform/variables.tf
+++ b/quick-start/terraform/variables.tf
@@ -25,7 +25,6 @@ variable "dns_host" {
 variable "allowed_ssh_cidr_blocks" {
   description = "A list of CIDR-formatted IP address ranges from which the EC2 Instance will allow SSH connections"
   type        = list(string)
-  # To restrict to a single IP, e.g. 75.75.75.75, use 75.75.75.75/32
   default     = ["0.0.0.0/0"]
 }
 
@@ -39,26 +38,6 @@ variable "allow_outbound_cidr_blocks" {
   description = "Allow outbound traffic to these CIDR blocks"
   type        = list(string)
   default     = ["0.0.0.0/0"]
-}
-
-variable "vpc_cidr_block" {
-  description = "CIDR block for the dedicated VPC for this example"
-  type        = string
-  default     = "10.0.0.0/24"
-}
-
-variable "subnet_cidr_block" {
-  description = "CIDR block for the subnet in the VPC for the EC2 instance"
-  type        = string
-  default     = "10.0.0.0/28"
-}
-
-variable "private_ip_address" {
-  description = "The private IP address for the EC2 instance"
-  type        = string
-  # Note: AWS reserves the first 4 and last IP address in each subnet CIDR block
-  # https://stackoverflow.com/questions/64212709/how-do-i-assign-an-ec2-instance-to-a-fixed-ip-address-within-a-subnet
-  default     = "10.0.0.4"
 }
 
 variable "allow_inbound_http_nomad" {


### PR DESCRIPTION
Follow-up to https://github.com/fermyon/nomad-aws-demo/pull/1

Simplifies networking.  Instead of creating separate vpc, networking interface, route table and internet gateway resources, just use the default VPC.  I think this is acceptable for the quick-start scenario and as a bonus lowers the AWS footprint and cognitive overhead.

~~All changes apart from #1 are in 0b55cf45e8dc9096cfaf7652756498a9015aa3dd~~