### PR TITLE
feat(quick-start): add hippo reg mode, un and password

### DIFF
--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -93,8 +93,53 @@ terraform destroy
 Once this example has been deployed, you're ready to start building and deploying applications
 on the Fermyon Platform.
 
-Follow the [Spin documentation](https://spin.fermyon.dev/) or
+For in-depth guides, follow the [Spin documentation](https://spin.fermyon.dev/) or
 [Hippo documentation](https://docs.hippofactory.dev/) to get started.
+
+## Example flow
+
+Here's an example flow once `terraform apply` completes.
+
+First, export pertinent environment variables based on terraform output values:
+
+```console
+export DNS_DOMAIN=$(terraform output -raw eip_public_ip_address).$(terraform output -raw dns_host)
+export HIPPO_URL=$(terraform output -raw hippo_url)
+export HIPPO_USERNAME=$(terraform output -raw hippo_admin_username)
+export HIPPO_PASSWORD=$(terraform output -raw hippo_admin_password)
+export BINDLE_URL=$(terraform output -raw bindle_url)
+```
+
+Next, `cd` to your Spin app directory, login to Hippo and deploy your app.
+
+Here we've entered the [examples/http-rust](https://github.com/fermyon/spin/tree/main/examples/http-rust)
+directory in the [fermyon/spin](https://github.com/fermyon/spin) GitHub repository:
+
+```console
+$ cd ~/code/github.com/fermyon/spin/examples/http-rust
+
+$ hippo login
+Logged in as admin
+
+$ spin build
+<output omitted>
+
+$ spin deploy
+Successfully deployed application!
+```
+
+We can then hit our app's served route (`/hello`) via its https URL.
+
+```console
+$ curl https://spin-hello-world.spin-hello-world.hippo.${DNS_DOMAIN}/hello
+Hello, Fermyon!
+```
+
+A few notes:
+
+- It can take a few moments for Traefik to obtain the Let's Encrypt cert for the app domain
+- The current structure for an app's URL on Hippo is `https://<channel name>.<app name>.hippo.<domain>`.
+  When deploying with `spin deploy`, the app name is used for the hippo channel name as well.
 
 # Troubleshooting/Debugging
 

--- a/quick-start/terraform/ec2_assets/job/hippo.nomad
+++ b/quick-start/terraform/ec2_assets/job/hippo.nomad
@@ -21,6 +21,29 @@ variable "letsencrypt_env" {
   }
 }
 
+variable "registration_mode" {
+  type    = string
+  default = "AdministratorOnly"
+  description = "The Hippo registration mode. Options are 'Open', 'Closed' and 'AdministratorOnly'. (Default: AdministratorOnly)"
+
+  validation {
+    condition     = var.registration_mode == "Open" || var.registration_mode == "Closed" || var.registration_mode == "AdministratorOnly"
+    error_message = "The Hippo registration mode must be 'Open', 'Closed' or 'AdministratorOnly'."
+  }
+}
+
+variable "admin_username" {
+  type        = string
+  description = "Username for the admin account"
+  default     = null
+}
+
+variable "admin_password" {
+  type        = string
+  description = "Password for the admin account"
+  default     = null
+}
+
 job "hippo" {
   datacenters = ["dc1"]
   type        = "service"
@@ -64,8 +87,16 @@ job "hippo" {
       driver = "raw_exec"
 
       env {
+        # Enable for debug logging
+        # Logging__LogLevel__Default = "Debug"
+
         Hippo__PlatformDomain = var.domain
         Scheduler__Driver     = "nomad"
+
+        # Registration configuration
+        Hippo__RegistrationMode            = var.registration_mode
+        Hippo__Administrators__0__Username = var.registration_mode == "AdministratorOnly" ? var.admin_username : ""
+        Hippo__Administrators__0__Password = var.registration_mode == "AdministratorOnly" ? var.admin_password : ""
 
         # Database Driver: inmemory, sqlite, postgresql
         Database__Driver            = "sqlite"

--- a/quick-start/terraform/ec2_assets/run_servers.sh
+++ b/quick-start/terraform/ec2_assets/run_servers.sh
@@ -23,7 +23,7 @@ require bindle-server
 
 cleanup() {
   echo
-  echo "Sutting down services"
+  echo "Shutting down services"
   kill $(jobs -p)
   wait
 }
@@ -89,6 +89,9 @@ nomad run \
 echo "Starting hippo job..."
 nomad run \
   -var domain="hippo.${DNS_ZONE}" \
+  -var registration_mode="${HIPPO_REGISTRATION_MODE}" \
+  -var admin_username="${HIPPO_ADMIN_USERNAME}" \
+  -var admin_password="${HIPPO_ADMIN_PASSWORD}" \
   -var bindle_url="https://bindle.${DNS_ZONE}/v1" \
   -var letsencrypt_env="${LETSENCRYPT_ENV}" \
   job/hippo.nomad

--- a/quick-start/terraform/outputs.tf
+++ b/quick-start/terraform/outputs.tf
@@ -14,6 +14,11 @@ output "eip_public_ip_address" {
   value       = aws_eip.lb.public_ip
 }
 
+output "dns_host" {
+  description = "The DNS host to use for construction of the root domain for Fermyon Platform services and apps"
+  value       = var.dns_host
+}
+
 output "bindle_url" {
   description = "The URL for the Bindle server"
   value       = "https://bindle.${aws_eip.lb.public_ip}.${var.dns_host}/v1"
@@ -22,4 +27,15 @@ output "bindle_url" {
 output "hippo_url" {
   description = "The URL for the Hippo server"
   value       = "https://hippo.${aws_eip.lb.public_ip}.${var.dns_host}"
+}
+
+output "hippo_admin_username" {
+  description = "Admin username for Hippo when running in AdministratorOnly mode"
+  value       = var.hippo_admin_username
+}
+
+output "hippo_admin_password" {
+  description = "Admin password for Hippo when running in AdministratorOnly mode"
+  value       = random_password.hippo_admin_password.result
+  sensitive   = true
 }

--- a/quick-start/terraform/scripts/user-data.sh
+++ b/quick-start/terraform/scripts/user-data.sh
@@ -100,8 +100,12 @@ sudo tar zxvf hippo-server-linux-x64.tar.gz -C /home/ubuntu/hippo
 cd /home/ubuntu
 sudo chmod +x run_servers.sh
 
-export DNS_ZONE="${dns_zone}"
-export LETSENCRYPT_ENV="${letsencrypt_env}"
+export HIPPO_ADMIN_USERNAME='${hippo_admin_username}'
+export HIPPO_ADMIN_PASSWORD='${hippo_admin_password}'
+export HIPPO_REGISTRATION_MODE='${hippo_registration_mode}'
+
+export DNS_ZONE='${dns_zone}'
+export LETSENCRYPT_ENV='${letsencrypt_env}'
 
 echo "Running servers using DNS zone '$DNS_ZONE' and Let's Encrypt env '$LETSENCRYPT_ENV'"
 ./run_servers.sh

--- a/quick-start/terraform/variables.tf
+++ b/quick-start/terraform/variables.tf
@@ -51,3 +51,20 @@ variable "allow_inbound_http_consul" {
   type        = bool
   default     = false
 }
+
+variable "hippo_admin_username" {
+  description = "Admin username for Hippo when running in AdministratorOnly mode"
+  type        = string
+  default     = "admin"
+}
+
+variable "hippo_registration_mode" {
+  description = "The registration mode for Hippo. Options are 'Open', 'Closed' and 'AdministratorOnly'. (Default: AdministratorOnly)"
+  type        = string
+  default     = "AdministratorOnly"
+
+  validation {
+    condition     = var.hippo_registration_mode == "Open" || var.hippo_registration_mode == "Closed" || var.hippo_registration_mode == "AdministratorOnly"
+    error_message = "The Hippo registration mode must be 'Open', 'Closed' or 'AdministratorOnly'."
+  }
+}


### PR DESCRIPTION
* adds support for choosing the registration mode for Hippo and adds admin un/pw generation
* Default Hippo reg mode is 'AdministatorOnly'

