### PR TITLE
ref(quick-start): Use http for services if Let's Encrypt is disabled

### DIFF
--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -11,7 +11,7 @@ without any redundancy on a single EC2 instance. There is no data backup for any
 service.
 
 That being said, it should give users a quick look and feel for deploying apps
-onto the Fermyon Platform. Apps will by default be provided with TLS certs via
+using Fermyon. Apps will by default be provided with TLS certs via
 Traefik's Let's Encrypt integration and will be accessible to the broader internet
 (depending on configuration details mentioned below).
 
@@ -68,16 +68,16 @@ cd terraform
 terraform init
 ```
 
-Deploy with all defaults and using the Let's Encrypt staging URL for testing:
+Deploy with all defaults (http-based URLs):
 
 ```console
 terraform apply
 ```
 
-Deploy with all defaults and using the Let's Encrypt prod URL for happy TLS:
+Deploy with all defaults and use Let's Encrypt to provision certs for TLS/https:
 
 ```console
-terraform apply -var='letsencrypt_env=prod'
+terraform apply -var='enable_letsencrypt=true'
 ```
 
 Deploy with a custom instance name, perhaps so multiple examples can co-exist in the same region:
@@ -126,9 +126,7 @@ commands below:
   - `HIPPO_URL`
   - `BINDLE_URL`
 
-Next, `cd` to your Spin app directory, login to Hippo and deploy your app. (Note: the `hippo login`
-and `spin deploy` commands may require `-k` if running with the `letsencrypt_env` variable
-set to `staging`; which is the current default.)
+Next, `cd` to your Spin app directory, login to Hippo and deploy your app.
 
 Here we've entered the [examples/http-rust](https://github.com/fermyon/spin/tree/main/examples/http-rust)
 directory in the [fermyon/spin](https://github.com/fermyon/spin) GitHub repository:
@@ -154,14 +152,14 @@ For example, when using the default DNS host of `sslip.io`, hitting the endpoint
 the following:
 
 ```console
-$ curl https://spin-deploy.spin-hello-world.hippo.52.44.146.193.sslip.io/hello
+$ curl http://spin-deploy.spin-hello-world.hippo.52.44.146.193.sslip.io/hello
 Hello, Fermyon!
 ```
 
 A few notes:
 
 - It can take a few moments for Traefik to obtain the Let's Encrypt cert for the app domain
-- The current structure for an app's URL on Hippo is `https://<channel name>.<app name>.hippo.<domain>`.
+- The current structure for an app's URL on Hippo is `http(s)://<channel name>.<app name>.hippo.<domain>`.
   When deploying with `spin deploy`, the app name is used for the hippo channel name as well.
 
 # Troubleshooting/Debugging

--- a/quick-start/terraform/ec2_assets/job/traefik.nomad
+++ b/quick-start/terraform/ec2_assets/job/traefik.nomad
@@ -50,11 +50,6 @@ job "traefik" {
 [entryPoints]
   [entryPoints.web]
     address = ":80"
-    [entryPoints.web.http]
-      [entryPoints.web.http.redirections]
-        [entryPoints.web.http.redirections.entryPoint]
-          to = "websecure"
-          scheme = "https"
 
   [entryPoints.websecure]
     address = ":443"
@@ -64,16 +59,13 @@ job "traefik" {
     address = ":8081"
 
 # Let's Encrypt TLS
-[certificatesResolvers.letsencrypt-tls-staging.acme]
-  email = "fermyon-hashistack-demo@fermyon.dev"
+[certificatesResolvers.letsencrypt-tls.acme]
+  # Supply an email to get cert expiration notices
+  # email = "you@example.com"
+  # The CA server can be toggled to staging for testing/avoiding rate limits
+  # caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
   storage = "/acme.json"
-  caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
-  [certificatesResolvers.letsencrypt-tls-staging.acme.tlsChallenge]
-
-[certificatesResolvers.letsencrypt-tls-prod.acme]
-  email = "fermyon-hashistack-demo@fermyon.dev"
-  storage = "/acme.json"
-  [certificatesResolvers.letsencrypt-tls-prod.acme.tlsChallenge]
+  [certificatesResolvers.letsencrypt-tls.acme.tlsChallenge]
 
 [api]
     dashboard = true

--- a/quick-start/terraform/ec2_assets/run_servers.sh
+++ b/quick-start/terraform/ec2_assets/run_servers.sh
@@ -4,7 +4,13 @@ set -euo pipefail
 # Derived from https://github.com/fermyon/nomad-local-demo
 
 export DNS_ZONE="${DNS_ZONE:-local.fermyon.link}"
-export LETSENCRYPT_ENV="${LETSENCRYPT_ENV:-staging}"
+export ENABLE_LETSENCRYPT="${ENABLE_LETSENCRYPT:-false}"
+
+if $ENABLE_LETSENCRYPT; then
+  export PLATFORM_PROTOCOL="https"
+else
+  export PLATFORM_PROTOCOL="http"
+fi
 
 export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=devroot
@@ -83,7 +89,7 @@ nomad run job/traefik.nomad
 echo "Starting bindle job..."
 nomad run \
   -var domain="bindle.${DNS_ZONE}" \
-  -var letsencrypt_env="${LETSENCRYPT_ENV}" \
+  -var enable_letsencrypt="${ENABLE_LETSENCRYPT}" \
   job/bindle.nomad
 
 echo "Starting hippo job..."
@@ -92,8 +98,8 @@ nomad run \
   -var registration_mode="${HIPPO_REGISTRATION_MODE}" \
   -var admin_username="${HIPPO_ADMIN_USERNAME}" \
   -var admin_password="${HIPPO_ADMIN_PASSWORD}" \
-  -var bindle_url="https://bindle.${DNS_ZONE}/v1" \
-  -var letsencrypt_env="${LETSENCRYPT_ENV}" \
+  -var bindle_url="${PLATFORM_PROTOCOL}://bindle.${DNS_ZONE}/v1" \
+  -var enable_letsencrypt="${ENABLE_LETSENCRYPT}" \
   job/hippo.nomad
 
 echo
@@ -103,7 +109,7 @@ echo "Consul:  http://localhost:8500"
 echo "Nomad:   http://localhost:4646"
 echo "Vault:   http://localhost:8200"
 echo "Traefik: http://localhost:8081"
-echo "Hippo:   https://hippo.${DNS_ZONE}"
+echo "Hippo:   ${PLATFORM_PROTOCOL}://hippo.${DNS_ZONE}"
 echo
 echo "Logs are stored in ./log"
 echo
@@ -114,8 +120,8 @@ echo "    export NOMAD_ADDR=http://127.0.0.1:4646"
 echo "    export VAULT_ADDR=${VAULT_ADDR}"
 echo "    export VAULT_TOKEN=$(<data/vault/token)"
 echo "    export VAULT_UNSEAL=$(<data/vault/unseal)"
-echo "    export BINDLE_URL=https://bindle.${DNS_ZONE}/v1"
-echo "    export HIPPO_URL=https://hippo.${DNS_ZONE}"
+echo "    export BINDLE_URL=${PLATFORM_PROTOCOL}://bindle.${DNS_ZONE}/v1"
+echo "    export HIPPO_URL=${PLATFORM_PROTOCOL}://hippo.${DNS_ZONE}"
 echo
 echo "Ctrl+C to exit."
 echo

--- a/quick-start/terraform/main.tf
+++ b/quick-start/terraform/main.tf
@@ -100,8 +100,8 @@ resource "aws_instance" "ec2" {
 
   user_data = templatefile("${path.module}/scripts/user-data.sh",
     {
-      dns_zone                = var.dns_host == "sslip.io" ? "${aws_eip.lb.public_ip}.${var.dns_host}" : "${var.dns_host}",
-      letsencrypt_env         = var.letsencrypt_env,
+      dns_zone                = var.dns_host == "sslip.io" ? "${aws_eip.lb.public_ip}.${var.dns_host}" : var.dns_host,
+      enable_letsencrypt      = var.enable_letsencrypt,
 
       nomad_version           = local.nomad_version,
       nomad_checksum          = local.nomad_checksum,
@@ -168,7 +168,7 @@ resource "aws_security_group_rule" "allow_ssh_inbound" {
 }
 
 resource "aws_security_group_rule" "allow_traefik_app_http_inbound" {
-  count       = length(var.allowed_inbound_cidr_blocks) > 0 ? 1 : 0
+  count       = !var.enable_letsencrypt && length(var.allowed_inbound_cidr_blocks) > 0 ? 1 : 0
   type        = "ingress"
   from_port   = 80
   to_port     = 80
@@ -179,7 +179,7 @@ resource "aws_security_group_rule" "allow_traefik_app_http_inbound" {
 }
 
 resource "aws_security_group_rule" "allow_traefik_app_https_inbound" {
-  count       = length(var.allowed_inbound_cidr_blocks) > 0 ? 1 : 0
+  count       = var.enable_letsencrypt && length(var.allowed_inbound_cidr_blocks) > 0 ? 1 : 0
   type        = "ingress"
   from_port   = 443
   to_port     = 443

--- a/quick-start/terraform/outputs.tf
+++ b/quick-start/terraform/outputs.tf
@@ -21,12 +21,12 @@ output "dns_host" {
 
 output "bindle_url" {
   description = "The URL for the Bindle server"
-  value       = var.dns_host == "sslip.io" ? "https://bindle.${aws_eip.lb.public_ip}.${var.dns_host}/v1" : "https://bindle.${var.dns_host}/v1"
+  value       =  "${var.enable_letsencrypt ? "https" : "http"}://bindle.${var.dns_host == "sslip.io" ? "${aws_eip.lb.public_ip}.${var.dns_host}" : var.dns_host}/v1"
 }
 
 output "hippo_url" {
   description = "The URL for the Hippo server"
-  value       = var.dns_host == "sslip.io" ? "https://hippo.${aws_eip.lb.public_ip}.${var.dns_host}" : "https://hippo.${var.dns_host}"
+  value       = "${var.enable_letsencrypt ? "https" : "http"}://hippo.${var.dns_host == "sslip.io" ? "${aws_eip.lb.public_ip}.${var.dns_host}" : var.dns_host}"
 }
 
 output "hippo_admin_username" {
@@ -44,10 +44,10 @@ output "environment" {
   description = "Get environment config by running: $(terraform output -raw environment)"
   sensitive   = true
   value       = <<EOM
-export HIPPO_URL=${var.dns_host == "sslip.io" ? "https://hippo.${aws_eip.lb.public_ip}.${var.dns_host}" : "https://hippo.${var.dns_host}"}
+export HIPPO_URL=${var.enable_letsencrypt ? "https" : "http"}://hippo.${var.dns_host == "sslip.io" ? "${aws_eip.lb.public_ip}.${var.dns_host}" : var.dns_host}
 export HIPPO_USERNAME=${var.hippo_admin_username}
 export HIPPO_PASSWORD=${random_password.hippo_admin_password.result}
-export BINDLE_URL=${var.dns_host == "sslip.io" ? "https://bindle.${aws_eip.lb.public_ip}.${var.dns_host}/v1" : "https://bindle.${var.dns_host}/v1"}
+export BINDLE_URL=${var.enable_letsencrypt ? "https" : "http"}://bindle.${var.dns_host == "sslip.io" ? "${aws_eip.lb.public_ip}.${var.dns_host}" : var.dns_host}/v1
 
 EOM
 }

--- a/quick-start/terraform/scripts/user-data.sh
+++ b/quick-start/terraform/scripts/user-data.sh
@@ -105,7 +105,7 @@ export HIPPO_ADMIN_PASSWORD='${hippo_admin_password}'
 export HIPPO_REGISTRATION_MODE='${hippo_registration_mode}'
 
 export DNS_ZONE='${dns_zone}'
-export LETSENCRYPT_ENV='${letsencrypt_env}'
+export ENABLE_LETSENCRYPT='${enable_letsencrypt}'
 
-echo "Running servers using DNS zone '$DNS_ZONE' and Let's Encrypt env '$LETSENCRYPT_ENV'"
+echo "Running servers using DNS zone '$DNS_ZONE'"
 ./run_servers.sh

--- a/quick-start/terraform/variables.tf
+++ b/quick-start/terraform/variables.tf
@@ -10,10 +10,10 @@ variable "instance_type" {
   default     = "t2.small"
 }
 
-variable "letsencrypt_env" {
-  description = "The Let's Encrypt URL to request certs from. Options are 'staging' or 'prod'."
-  type        = string
-  default     = "staging"
+variable "enable_letsencrypt" {
+  description = "Enable cert provisioning via Let's Encrypt"
+  type        = bool
+  default     = false
 }
 
 variable "dns_host" {


### PR DESCRIPTION
Update automation such that the default URLs are http-based but with option to use LE for tls.

Closes https://github.com/fermyon/nomad-aws-demo/issues/16