### PR TITLE
fix(main.tf): supply curated list of special chars

### DIFF
--- a/quick-start/terraform/main.tf
+++ b/quick-start/terraform/main.tf
@@ -242,4 +242,5 @@ resource "aws_key_pair" "ec2_ssh_key_pair" {
 resource "random_password" "hippo_admin_password" {
   length           = 22
   special          = true
+  override_special = "!#%&*-_=+<>:?"
 }


### PR DESCRIPTION
* Curates a specific list of special chars for use in the hippo password

Motivated by cases like the following:

```
$ printf $HIPPO_PASSWORD | pbcopy
-bash: printf: `[': invalid format character
```